### PR TITLE
Check if cron.lock is older than 59 minutes

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -19,14 +19,10 @@ function cleanup() {
 
 trap cleanup 1 2 3 6 9 15
 
-if [ ! -f $lockfile ];then
+if [ ! -f $lockfile ] || [ $(find $lockfile -mmin +59) ]; then
     echo $$ > $lockfile
 else
-    if [ $(find $lockfile -mmin +59) ];then
-        rm -f $lockfile
-    else
-        exit 0
-    fi
+    exit 0
 fi
 
 if [ -n "$1" ] ; then

--- a/cron.sh
+++ b/cron.sh
@@ -22,7 +22,11 @@ trap cleanup 1 2 3 6 9 15
 if [ ! -f $lockfile ];then
     echo $$ > $lockfile
 else
-    exit 0
+    if [ $(find $lockfile -mmin +59) ];then
+        rm -f $lockfile
+    else
+        exit 0
+    fi
 fi
 
 if [ -n "$1" ] ; then


### PR DESCRIPTION
To avoid that the magento-cron is not running for weeks, the cron.sh should check the age of cron.lock. I chose 59 minutes because 60 minutes is to mainstream. (:

Regards
Hermsi