### PR TITLE
Create aoe_scheduler_cron.sh

### DIFF
--- a/aoe_scheduler_cron.sh
+++ b/aoe_scheduler_cron.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+HOME="/home/www/pXXXXXX"
+BASE="$HOME/html/production/web"
+
+cd $BASE || exit 1
+
+unset REQUEST_METHOD
+
+! test -e maintenance.flag && /bin/bash scheduler_cron.sh --mode always
+! test -e maintenance.flag && /bin/bash scheduler_cron.sh --mode default


### PR DESCRIPTION
add a custom sh file for use with the AOE Scheduler extension, because There is no possibility to set --mode parameters in Mittwald backend.